### PR TITLE
Add Rack::Deflater middleware for optionally compressing responses.

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'bundler/setup'
 require 'sinatra/base'
+require 'rack/deflater'
 require 'pathname'
 
 class App < Sinatra::Base
@@ -53,4 +54,5 @@ class App < Sinatra::Base
   end
 end
 
+use Rack::Deflater
 run App


### PR DESCRIPTION
This will _greatly_ reduce the API response sizes. Seemingly an average of about a 70% reduction in the transmitted byte size.
