### PR TITLE
Stipulate the response charset in the response header.

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -7,7 +7,7 @@ class App < Sinatra::Base
   CONTENT_TYPE = 'text/plain'.freeze
   TEXT_HEADERS = {
     'Access-Control-Allow-Origin'.freeze => '*'.freeze,
-    'Content-Type'.freeze => CONTENT_TYPE
+    'Content-Type'.freeze => "#{CONTENT_TYPE}; charset=utf-8".freeze
   }.freeze
   PATH = Pathname.new(__FILE__).join('../generated'.freeze).freeze
   STATUS = 'alive'.freeze


### PR DESCRIPTION
This allows the client to more quickly begin parsing and interpreting the response.
